### PR TITLE
Add bower packages to project in afterInstall hook

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,5 +12,15 @@ module.exports = {
     app.import(app.bowerDirectory + '/jquery-mousewheel/jquery.mousewheel.js');
     app.import(app.bowerDirectory + '/ember-table/dist/ember-table.js');
     app.import(app.bowerDirectory + '/ember-table/dist/ember-table.css');
+  },
+
+  afterInstall: function() {
+    this.addBowerPackageToProject('antiscroll');
+    this.addBowerPackageToProject('bootstrap');
+    this.addBowerPackageToProject('ember');
+    this.addBowerPackageToProject('handlebars');
+    this.addBowerPackageToProject('jquery');
+    this.addBowerPackageToProject('jquery-mousewheel');
+    this.addBowerPackageToProject('jquery-ui');
   }
 };


### PR DESCRIPTION
Not 100% sure if we need all of these but it now installs in an ember-cli app and installs all the necessary deps when you do `ember generate ember-table`
