### PR TITLE
Escape style bindings

### DIFF
--- a/addon/mixins/style-bindings.js
+++ b/addon/mixins/style-bindings.js
@@ -42,7 +42,7 @@ export default Ember.Mixin.create({
       });
       styleString = styleTokens.join('');
       if (styleString.length !== 0) {
-        return styleString;
+        return styleString.htmlSafe().toString();
       }
     });
     styleComputed.property.apply(styleComputed, properties);


### PR DESCRIPTION
Fixes the warnings about unescaped style strings. Works with both old and new handlebars. Works with the demo app.